### PR TITLE
improve web accessibility

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,16 +1,19 @@
 export default function Index() {
   return (
     <div className="px-4 lg:px-0">
-      <div className="fixed left-0 right-0 backdrop-blur-sm bg-base-100/80">
+      <header className="fixed left-0 right-0 backdrop-blur-sm bg-base-100/80">
         <div className="container mx-auto max-w-screen-lg text-5xl px-4 lg:px-0">
           <div className="flex flex-row justify-between items-center h-20">
-            <img src="images/logo.svg" />
+            <img src="images/logo.svg" alt="Gramatika" />
             <div className="flex flex-row space-x-4">
               <div className="flex flex-row">
                 <div className="form-control">
+                  <label className="sr-only" htmlFor="color-toggle">Ubah mode warna</label>
                   <input
                     type="checkbox"
                     defaultChecked={true}
+                    id="color-toggle"
+                    name="color-toggle"
                     className="toggle"
                     onChange={(e) => {
                       try {
@@ -23,28 +26,28 @@ export default function Index() {
                     }}
                   />
                 </div>
-                <img src="images/light_mode.svg" className="ml-1" />
+                <img src="images/light_mode.svg" className="ml-1" role="presentation" />
               </div>
               <a
                 href="https://twitter.com/sonnylazuardi"
                 className="text-sm text-black lg:text-base flex flex-row items-end font-semibold"
               >
-                <span className="hidden md:inline-block">@sonnylazuardi</span>{" "}
-                <img src="images/arrow_black.svg" className="mb-1 ml-1" />
+                <span className="sr-only md:not-sr-only md:inline-block">@sonnylazuardi</span>{" "}
+                <img src="images/arrow_black.svg" className="mb-1 ml-1" role="presentation" />
               </a>
             </div>
           </div>
         </div>
-      </div>
+      </header>
       <div className="container mx-auto max-w-screen-lg text-5xl">
         <div className="flex flex-col justify-center items-center mb-12">
-          <div className="mt-32 text-center max-w-2xl text-3xl lg:text-6xl mb-4 font-bold">
+          <h1 className="mt-32 text-center max-w-2xl text-3xl lg:text-6xl mb-4 font-bold">
             Memperkenalkan Gramatika!
-          </div>
-          <div className="text-base font-normal text-center max-w-md">
+          </h1>
+          <p className="text-base font-normal text-center max-w-md">
             Asisten menulis Bahasa Indonesia baku di peramban (browser) dan
             aplikasi ponsel.
-          </div>
+          </p>
         </div>
         <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-10 mb-4 lg:mb-0">
           <div className="flex flex-row justify-center lg:justify-end">
@@ -52,10 +55,10 @@ export default function Index() {
               href="https://chrome.google.com/webstore/detail/gramatika-bahasa-indonesi/hhodeijkemcdbelkfdhglgmgpmgkfekk?hl=id"
               className="bg-black text-white text-sm flex flex-row p-4 items-center justify-center rounded-tl-2xl rounded-tr-2xl rounded-bl-2xl font-semibold"
             >
-              <img src="images/chrome_logo.png" className="mr-4" />
+              <img src="images/chrome_logo.png" className="mr-4" role="presentation" />
               Pasang Pengaya di
               <br /> Chrome Webstore{" "}
-              <img src="images/arrow_white.svg" className="ml-4" />
+              <img src="images/arrow_white.svg" className="ml-4" role="presentation" />
             </a>
           </div>
           <div className="flex flex-row justify-center lg:justify-start">
@@ -63,19 +66,19 @@ export default function Index() {
               href="https://twitter.com/sonnylazuardi/status/1476510329471258624?s=20"
               className="border border-base-content border-solid bg-base-100 text-base-content text-sm flex flex-row p-4 items-center justify-center rounded-tl-2xl rounded-tr-2xl rounded-br-2xl font-semibold"
             >
-              <img src="images/android_logo.png" className="mr-4" />
+              <img src="images/android_logo.png" className="mr-4" role="presentation" />
               Aplikasi Ponsel dalam
               <br /> Pengembangan{" "}
-              <img src="images/arrow_black.svg" className=" ml-4" />
+              <img src="images/arrow_black.svg" className="ml-4" role="presentation" />
             </a>
           </div>
         </div>
         <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-10 mb-20">
           <div className="bg-base-300 h-96 flex items-center justify-center rounded-tl-2xl rounded-bl-2xl rounded-br-2xl mb-4 overflow-hidden">
-            <img src="images/extension.png" style={{ width: 450 }} />
+            <img src="images/extension.png" role="presentation" style={{ width: 450 }} />
           </div>
           <div className="bg-base-300 h-96 flex items-center justify-center rounded-tr-2xl rounded-bl-2xl rounded-br-2xl mb-4 overflow-hidden">
-            <img src="images/mobile.png" style={{ width: 450 }} />
+            <img src="images/mobile.png" role="presentation" style={{ width: 450 }} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Improve accessibility score on Lighthouse from 60 to 100:

- Use proper semantic elements for texts (`<h1>`, `<p>`) and other elements (`<header>`)
- Added proper alt text for images, or mark it with `role="presentation"` if it's only for presentational purposes
- Replace `.hidden` with `.sr-only` for hideable text that are screen-reader friendly.
- Add proper label text (`.sr-only`) for color mode toggle.

## Before

![image](https://user-images.githubusercontent.com/5663877/147845992-8d38f8a6-d7f0-45a0-9a59-af52c0571faa.png)

## After

![image](https://user-images.githubusercontent.com/5663877/147845997-45f302ba-eaec-40aa-b1d4-d3c0eddf3b3b.png)
